### PR TITLE
Configure cloud-build to commit Kubernetes resources

### DIFF
--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -3,12 +3,58 @@ steps:
     args: ["build", "-t", "gcr.io/$PROJECT_ID/ultimanager-web:$COMMIT_SHA", "."]
 
   - name: "gcr.io/cloud-builders/docker"
-    args: ["push", "gcr.io/$PROJECT_ID/ultimanager-web:$COMMIT_SHA"]
+    args: ["push", "gcr.io/$PROJECT_ID/${_IMAGE_NAME}:$COMMIT_SHA"]
 
-  - name: "gcr.io/cloud-builders/gke-deploy:stable"
+  # Clone the cluster state repository.
+  - name: "gcr.io/cloud-builders/gcloud"
+    id: Clone env repository
+    entrypoint: /bin/sh
+    volumes:
+      - name: cluster-state
+        path: /cluster-state
     args:
-      - run
-      - --filename=deployment
-      - --image=gcr.io/$PROJECT_ID/ultimanager-web:$COMMIT_SHA
-      - --location=$_K8S_CLUSTER_LOCATION
-      - --cluster=$_K8S_CLUSTER_NAME
+      - "-c"
+      - |
+        gcloud source repos clone ${_K8S_STATE_REPO_NAME} /cluster-state/ && \
+        cd /cluster-state/ && \
+        git checkout master || git checkout -b master && \
+        git config user.email $(gcloud auth list --filter=status:ACTIVE --format='value(account)')
+
+  # Generate the new manifest
+  - name: "gcr.io/cloud-builders/gcloud"
+    id: Generate manifest
+    entrypoint: /bin/sh
+    volumes:
+      - name: cluster-state
+        path: /cluster-state
+    args:
+      - "-c"
+      - |
+        mkdir -p /cluster-state/ultimanager-web && \
+        rm -rf /cluster-state/ultimanager-web/* && \
+        sed "s;@IMAGE_REPO@;gcr.io/$PROJECT_ID;g" deployment/deployment.yml.tpl | \
+        sed "s;@IMAGE_NAME@;$_IMAGE_NAME;g" | \
+        sed "s;@IMAGE_TAG@;$COMMIT_SHA;g" > /cluster-state/ultimanager-web/deployment.yml && \
+        cp deployment/service.yml /cluster-state/ultimanager-web/ && \
+        cp deployment/virtualService.yaml /cluster-state/ultimanager-web/
+
+  # This step pushes the manifest back to hello-cloudbuild-env
+  - name: "gcr.io/cloud-builders/gcloud"
+    id: Push manifest
+    entrypoint: /bin/sh
+    volumes:
+      - name: cluster-state
+        path: /cluster-state
+    args:
+      - "-c"
+      - |
+        set -x && \
+        cd /cluster-state/ && \
+        git add ultimanager-web/ && \
+        git commit -m "Deploying image gcr.io/${PROJECT_ID}/${_IMAGE_NAME}:${COMMIT_SHA}
+        Built from commit ${COMMIT_SHA} of repository UltiManager/ultimanager-web
+        Author: $(git log --format='%an <%ae>' -n 1 HEAD)" && \
+        git push origin master
+
+substitutions:
+  _IMAGE_NAME: ultimanager-web

--- a/deployment/deployment.yml.tpl
+++ b/deployment/deployment.yml.tpl
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: ultimanager-web
-          image: gcr.io/ultimanager-prod/ultimanager-web
+          image: @IMAGE_REPO@/@IMAGE_NAME@:@IMAGE_TAG@
           env:
             - name: ULTIMANAGER_API_ROOT
               value: "http://localhost:8000"

--- a/deployment/service.yml
+++ b/deployment/service.yml
@@ -11,4 +11,3 @@ spec:
     - protocol: TCP
       port: 80
       targetPort: 80
-  type: NodePort

--- a/deployment/virtualService.yaml
+++ b/deployment/virtualService.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: ultimanager-web
+spec:
+  hosts:
+    - "*"
+  gateways:
+    - default-ingress.istio-system.svc.cluster.local
+  http:
+    - name: default
+      route:
+        - destination:
+            host: ultimanager-web


### PR DESCRIPTION
Instead of deploying our resources to the cluster directly, we push the
manfests to the environment state repository.